### PR TITLE
[FIX#1159] added 15 sec delay, synchronization delay in report-downlo…

### DIFF
--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -460,7 +460,10 @@
                 url: endpoint,
                 success: function(data) {
                     if (data.downloads.length) {
-                        return ths.create_report_downloads_table(data.downloads);
+                        // added 15 sec delay, - problems with ssynchronization, error 404
+                        setTimeout(function() {
+                            return ths.create_report_downloads_table(data.downloads);
+                        }, 15000);
                     } else {
                         return false;
                     }


### PR DESCRIPTION
Poproszę o review. Dodałem delay 15 sec. Dzięki czemu wyświetla nowy raport do pobrania z opóźnieniem, i unikamy w ten sposób błąd (404), opóźnienie w synchronizacji danych.