### PR TITLE
[imp#1174] added height: auto css attribute, in xmodule_HtmlModule im…

### DIFF
--- a/lms/static/sass/course-content.scss
+++ b/lms/static/sass/course-content.scss
@@ -10958,6 +10958,7 @@ main.container aside h6 {
 
   .xmodule_HtmlModule img {
     max-width: 100%;
+    height: auto;
   }
 
   .slick-column-name {


### PR DESCRIPTION
…g - responsive image height for mobile devices
poproszę o review. Wcześniej podczas zawężania okna (widok mobilny), wysokość obrazka pozostawała bez zmian, zaś szerokość się zawężała. W tej chwili wysokość dostosowuje się do szerokości.