### PR TITLE
Bugfix/Get sentry url setting from env json file instead of system env

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -23,7 +23,6 @@ from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 import sentry_sdk
-sentry_sdk.init(os.environ.get('SENTRY_URL_CMS', None))
 
 INTERNAL_HOST_IP = os.environ.get('INTERNAL_HOST_IP', None)
 
@@ -99,6 +98,9 @@ CELERY_ROUTES = "{}celery.Router".format(QUEUE_VARIANT)
 # Things like server locations, ports, etc.
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
+
+# initialize sentry logging; if None then its disabled
+sentry_sdk.init(ENV_TOKENS.get('SENTRY_URL', None))
 
 # Do NOT calculate this dynamically at startup with git because it's *slow*.
 EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REVISION)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -33,7 +33,7 @@ from xmodule.modulestore.modulestore_settings import convert_module_store_settin
 from django.utils.translation import ugettext_lazy as _
 
 import sentry_sdk
-sentry_sdk.init(os.environ.get('SENTRY_URL_LMS', None))
+
 
 INTERNAL_HOST_IP = os.environ.get('INTERNAL_HOST_IP', None)
 
@@ -118,6 +118,10 @@ CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this d
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
+
+# initialize sentry logging; if None then its disabled
+sentry_sdk.init(ENV_TOKENS.get('SENTRY_URL', None))
+
 # STATIC_ROOT specifies the directory where static files are
 # collected
 STATIC_ROOT_BASE = ENV_TOKENS.get('STATIC_ROOT_BASE', None)


### PR DESCRIPTION
Poprzednie rozwiązanie działało poprawnie ale tylko z lms i cms ponieważ klucze url były w lms.sh i cms.sh a worker.sh tego nie miało 