### PR TITLE
MOOC-1459 Fix: add _ function within _get_answer_notification method

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -773,6 +773,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
          Arguments:
              render_notifications (bool): If false the method will return an None for type and message
         """
+        _ = self.runtime.service(self, "i18n").ugettext
         answer_notification_message = None
         answer_notification_type = None
 


### PR DESCRIPTION
Translations of some words did not work, due to lack of missing i18n runtime service in _get_answer_notification method. This fix repair it