### PR TITLE
MOOC-1469 Fix: bump version of videojs-xblock to 1.1.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
 -e git+https://github.com/OPI-PIB/xblock-inline-dropdown.git#egg=xblock-inline-dropdown
 -e git+https://github.com/OPI-PIB/xblock-embedded-answers.git#egg=xblock-embedded-answers
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
--e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.3#egg=videojs-xblock
+-e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.4#egg=videojs-xblock
 -e git+https://github.com/OPI-PIB/xblock-audioplayer.git@0.1.1#egg=audioplayer-xblock==0.1.1
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -55,7 +55,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
 -e git+https://github.com/OPI-PIB/xblock-inline-dropdown.git#egg=xblock-inline-dropdown
 -e git+https://github.com/OPI-PIB/xblock-embedded-answers.git#egg=xblock-embedded-answers
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
--e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.3#egg=videojs-xblock
+-e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.4#egg=videojs-xblock
 -e git+https://github.com/OPI-PIB/xblock-audioplayer.git@0.1.1#egg=audioplayer-xblock==0.1.1
 -e common/lib/xmodule
 alabaster==0.7.10         # via sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -42,7 +42,7 @@ git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/OPI-PIB/xblock-poll.git@v2Navoica#egg=xblock-poll
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
--e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.3#egg=videojs-xblock
+-e git+https://github.com/OPI-PIB/videojsXBlock.git@1.1.4#egg=videojs-xblock
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.1.0


### PR DESCRIPTION
Accept first this PR: https://github.com/OPI-PIB/videojsXBlock/pull/1