### PR TITLE
MOOC-1742 FIX: show created_date on certificates instead of updated (…

### DIFF
--- a/openedx/core/djangoapps/certificates/api.py
+++ b/openedx/core/djangoapps/certificates/api.py
@@ -104,4 +104,4 @@ def display_date_for_certificate(course, certificate):
     ):
         return course.certificate_available_date
 
-    return certificate.modified_date
+    return certificate.created_date


### PR DESCRIPTION
… due to changed value of grade )