### PR TITLE
FIX: clear parent wrapper for zoomed image in xblock html

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/imageModal.js
+++ b/common/lib/xmodule/xmodule/js/src/html/imageModal.js
@@ -99,6 +99,11 @@ var setupFullScreenModal = function() {
               } else if ($(this).hasClass('action-zoom-out')) {
                   imageModal.removeClass('image-is-zoomed').addClass('image-is-fit-to-screen');
 
+                  img.parent().css({
+                      width: "auto",
+                      height: "auto"
+                  });
+
                   currentDraggie.disable();
               }
 


### PR DESCRIPTION
quick fix; prevent to decreasing size of zoomed image every time tapping "Powiększ"